### PR TITLE
Set default patient status to "Checked In"

### DIFF
--- a/backend/src/controllers/patientController.ts
+++ b/backend/src/controllers/patientController.ts
@@ -2,6 +2,8 @@ import { Request, Response } from 'express';
 import { Patient } from '../models/patientModel';
 import { generatePatientId } from '../utils/generatePatientId';
 
+const CHECKED_IN_STATUS_ID = '6876b51b6e7ee884eb6b67c3';
+
 export const createPatient = async (
   req: Request,
   res: Response
@@ -12,6 +14,7 @@ export const createPatient = async (
     const newPatient = await Patient.create({
       ...req.body,
       patientId: patientId,
+      status: CHECKED_IN_STATUS_ID,
     });
     return res.status(201).json(newPatient);
   } catch (error: any) {
@@ -27,7 +30,10 @@ export const getAllPatients = async (
   res: Response
 ): Promise<Response> => {
   try {
-    const patients = await Patient.find();
+    const patients = await Patient.find().populate({
+      path: 'status',
+      select: 'code -_id',
+    });
     return res.status(200).json(patients);
   } catch (error: any) {
     console.error('Error fetching patients:', error);

--- a/backend/src/controllers/statusController.ts
+++ b/backend/src/controllers/statusController.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response } from 'express';  
+import { Request, Response } from 'express';  
 import Status from '../models/Status';
 
 

--- a/backend/src/models/patientModel.ts
+++ b/backend/src/models/patientModel.ts
@@ -1,4 +1,5 @@
 import mongoose, { Document, Schema } from 'mongoose';
+import Status from './Status';
 
 export interface PatientType extends Document {
   patientId: string;
@@ -11,6 +12,7 @@ export interface PatientType extends Document {
   telephone: number;
   contactEmail: string;
   createdAt: Date;
+  status: mongoose.Types.ObjectId;
 }
 
 const patientSchema = new Schema<PatientType>({
@@ -24,6 +26,7 @@ const patientSchema = new Schema<PatientType>({
   telephone: { type: Number, required: true },
   contactEmail: { type: String, required: true },
   createdAt: { type: Date, default: Date.now },
+  status: { type: Schema.Types.ObjectId, ref: 'Status', required: true },
 });
 
 export const Patient = mongoose.model<PatientType>('Patient', patientSchema);


### PR DESCRIPTION
### Summary
- Updated the patient creation endpoint to automatically assign the default status "Checked In" by setting the correct Status ObjectId.
- Modified the getAllPatients endpoint to populate the patient's status field, returning only the code property instead of the entire status object or just the ObjectId.

### Details
- Used the existing "Checked In" Status document's ObjectId to set the default status during patient creation.
- Leveraged Mongoose's .populate() method with field selection to improve the API response for patient status.

### Testing
- Created new patients via API and confirmed status is properly set.
- Verified getAllPatients returns status code correctly populated.

### Create Patient testing with Postman
<img width="821" height="758" alt="image" src="https://github.com/user-attachments/assets/447c8a98-c22d-4507-84f8-d0b1aa455e03" />

### Get All Patient testing with Postman for status population
<img width="658" height="875" alt="image" src="https://github.com/user-attachments/assets/c26448c9-5d6b-4200-8ca0-90c28f2f945a" />
