### PR TITLE
Create separate API endpoint for generating patient ID

### DIFF
--- a/backend/src/controllers/patientController.ts
+++ b/backend/src/controllers/patientController.ts
@@ -4,16 +4,28 @@ import { generatePatientId } from '../utils/generatePatientId';
 
 const CHECKED_IN_STATUS_ID = '6876b51b6e7ee884eb6b67c3';
 
-export const createPatient = async (
+export const generateNewPatientId = async (
   req: Request,
   res: Response
 ): Promise<Response> => {
   try {
     const patientId = await generatePatientId();
+    return res.status(200).json({ patientId });
+  } catch (error: any) {
+    console.error('Error generating patient ID:', error);
+    return res
+      .status(500)
+      .json({ message: 'Failed to generate patient ID', error: error.message });
+  }
+};
 
+export const createPatient = async (
+  req: Request,
+  res: Response
+): Promise<Response> => {
+  try {
     const newPatient = await Patient.create({
       ...req.body,
-      patientId: patientId,
       status: CHECKED_IN_STATUS_ID,
     });
     return res.status(201).json(newPatient);

--- a/backend/src/routes/patientRoutes.ts
+++ b/backend/src/routes/patientRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import {
   createPatient,
+  generateNewPatientId,
   getAllPatients,
 } from '../controllers/patientController';
 
@@ -8,4 +9,6 @@ const router = Router();
 
 router.post('/newPatient', createPatient);
 router.get('/patients', getAllPatients);
+router.get('/generate-patient-id', generateNewPatientId);
+
 export default router;


### PR DESCRIPTION
### Summary:
This PR separates the logic for generating a patient ID from the createPatient API. A new endpoint, generateNewPatientId, has been introduced to handle patient ID generation independently.

### Changes Made:

- Added generateNewPatientId API endpoint
- Moved patient ID generation logic out of createNewPatient
- Updated error handling and response structure accordingly

### Reasoning:
During the sprint review, the Product Owner requested that the patient ID should already be generated and displayed when the user lands on the "Create Patient" form. To support this, the ID generation needed to occur before submitting the patient data, requiring a separate API endpoint.

###Testing:
Verified that the new endpoint returns a unique patient ID
<img width="679" height="667" alt="image" src="https://github.com/user-attachments/assets/f9071b52-f83e-4a15-950a-88f2f5106a5d" />

