### PR TITLE
bug:invalid patients id creation

### DIFF
--- a/backend/src/controllers/patientController.ts
+++ b/backend/src/controllers/patientController.ts
@@ -24,6 +24,7 @@ export const createPatient = async (
   res: Response
 ): Promise<Response> => {
   try {
+    if(req.body.patientId!=6) return res.status(400).json({ message: 'Failed to create patient'})
     const patientId = req.body.patientId || (await generatePatientId());
     const newPatient = await Patient.create({
       ...req.body,


### PR DESCRIPTION
Bug: Malicious user can enter patient id with length more than standerd length (eg: length=6) via using developer tool.
Bug fix: Removed the bug from patient creation form. 

<img width="571" height="370" alt="Screenshot from 2025-07-31 21-14-05" src="https://github.com/user-attachments/assets/9db47c42-8aeb-485a-98b2-f1aa2a899b1b" />

