### PR TITLE
fix: secure patient ID generation

### DIFF
--- a/backend/src/controllers/patientController.ts
+++ b/backend/src/controllers/patientController.ts
@@ -19,31 +19,12 @@ const calculateStatusDuration = (statusStartTime: Date, updatedAt: Date): string
   return `${mins}m`;
 };
 
-export const generateNewPatientId = async (
-  req: Request,
-  res: Response
-): Promise<Response> => {
-  try {
-    const patientId = await generatePatientId();
-    return res.status(200).json({ patientId });
-  } catch (error: any) {
-    console.error('Error generating patient ID:', error);
-    return res
-      .status(500)
-      .json({ message: 'Failed to generate patient ID', error: error.message });
-  }
-};
-
 export const createPatient = async (
   req: Request,
   res: Response
 ): Promise<Response> => {
   try {
-    if (req.body.patientId.length !== 6)
-      return res
-        .status(400)
-        .json({ message: 'Patient ID must be exactly 6 characters long' });
-    const patientId = req.body.patientId || (await generatePatientId());
+    const patientId = await generatePatientId();
     const newPatient = await Patient.create({
       ...req.body,
       patientId,

--- a/backend/src/routes/patientRoutes.ts
+++ b/backend/src/routes/patientRoutes.ts
@@ -1,7 +1,6 @@
 import { Router } from 'express';
 import {
   createPatient,
-  generateNewPatientId,
   getAllPatients,
   updatePatient,
   searchPatients,
@@ -19,7 +18,6 @@ router.use(authenticate);
 
 router.post('/newPatient', requireAdmin, createPatient);
 router.get('/patients', requireAdminOrSurgeryTeam, getAllPatients);
-router.get('/generate-patient-id', requireAdmin, generateNewPatientId);
 router.put('/patients/:patientId', requireAdmin, updatePatient);
 router.get('/search', requireAdminOrSurgeryTeam, searchPatients);
 router.patch(

--- a/frontend/src/components/PatientForm/PatientForm.tsx
+++ b/frontend/src/components/PatientForm/PatientForm.tsx
@@ -43,34 +43,6 @@ const PatientForm: React.FC<PatientFormProps> = ({
   const [successMessage, setSuccessMessage] = useState('');
   const [selectedStatus, setSelectedStatus] = useState<string>('');
 
-  // generate patient ID for create mode
-  useEffect(() => {
-    const handleCreateNewUser = async () => {
-      if (mode === 'create') {
-        try {
-          const token = await getToken();
-          const response = await axios.get(
-            `${BASE_URL}/admin/generate-patient-id`,
-            {
-              headers: {
-                Authorization: `Bearer ${token}`,
-              },
-            }
-          );
-          console.log(response);
-
-          setPatient((prev) => ({
-            ...prev,
-            patientId: response.data.patientId,
-          }));
-        } catch (err: any) {
-          console.error('Error generating new patient ID:', err);
-        }
-      }
-    };
-    handleCreateNewUser();
-  }, [mode, getToken]);
-
   // fetch statuses for edit mode
   useEffect(() => {
     const fetchStatuses = async () => {
@@ -229,19 +201,21 @@ const PatientForm: React.FC<PatientFormProps> = ({
 
         {error && <div className='error-message'>{error}</div>}
 
-        <div>
-          <label htmlFor='patientId'>Patient No.:</label>
-          <br />
-          <input
-            type='text'
-            id='patientId'
-            name='patientId'
-            value={patient.patientId}
-            onChange={handleChange}
-            readOnly
-            className='readonly-label'
-          />
-        </div>
+        {mode !== 'create' && (
+          <div>
+            <label htmlFor='patientId'>Patient No.:</label>
+            <br />
+            <input
+              type='text'
+              id='patientId'
+              name='patientId'
+              value={patient.patientId}
+              onChange={handleChange}
+              readOnly
+              className='readonly-label'
+            />
+          </div>
+        )}
         <div>
           <label htmlFor='firstName'>First Name:</label>
           <br />


### PR DESCRIPTION
I wanted to keep the `patientId` visible in `create` mode, but removing the `readonly` attribute made it editable. So, I decided to remove it entirely.